### PR TITLE
Add auditing support with Lombok and JPA auditing configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>annotationProcessor</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/ClinicwaveCoreDomainServiceApplication.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/ClinicwaveCoreDomainServiceApplication.java
@@ -2,8 +2,10 @@ package com.clinicwave.clinicwavecoredomainservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
 public class ClinicwaveCoreDomainServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/audit/Audit.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/audit/Audit.java
@@ -1,0 +1,44 @@
+package com.clinicwave.clinicwavecoredomainservice.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * @author aamir on 5/27/24
+ */
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+public abstract class Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @CreatedDate
+  @Column(updatable = false, nullable = false)
+  private LocalDateTime createdAt;
+
+  @CreatedBy
+  @Column(updatable = false, nullable = false, length = 20)
+  private String createdBy;
+
+  @LastModifiedDate
+  @Column(insertable = false)
+  private LocalDateTime updatedAt;
+
+  @LastModifiedBy
+  @Column(insertable = false, length = 20)
+  private String updatedBy;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/audit/AuditorAwareImpl.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/audit/AuditorAwareImpl.java
@@ -1,0 +1,26 @@
+package com.clinicwave.clinicwavecoredomainservice.audit;
+
+import lombok.NonNull;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * @author aamir on 5/27/24
+ */
+@Component(value = "auditorAwareImpl")
+public class AuditorAwareImpl implements AuditorAware<String> {
+  /**
+   * Returns the current auditor of the application.
+   *
+   * @return the current auditor
+   *
+   * TODO: Retrieve the current user from the security context
+   */
+  @Override
+  @NonNull
+  public Optional<String> getCurrentAuditor() {
+      return Optional.of("user");
+  }
+}


### PR DESCRIPTION
### Description:
This pull request introduces JPA auditing functionality to the codebase, enabling automatic capture of auditing information for entities.

### Changes:
- **Lombok Dependency:** Added Lombok dependency to `pom.xml` for annotation processing.
- **JPA Auditing Enabled:** Enabled JPA auditing in the main application class.
- **Audit Class:** Created `Audit` class for auditing fields (`createdAt`, `createdBy`, `updatedAt`, `updatedBy`) with annotations for automatic population.
- **Auditor Aware Implementation:** Implemented `AuditorAwareImpl` to return the current auditor (currently a placeholder returning "user").

### Purpose:
The purpose of this pull request is to provide a framework for automatically capturing auditing information for entities, improving the traceability and accountability within the application.
