### PR TITLE
Add Address Entity and Update ClinicWaveUser Entity

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/Address.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/Address.java
@@ -1,0 +1,37 @@
+package com.clinicwave.clinicwavecoredomainservice.user;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * @author aamir on 5/30/24
+ */
+@Entity
+@Table(name = "Address")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class Address extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  private String addressLine;
+
+  private String country;
+
+  private String city;
+
+  private String state;
+
+  private String zipCode;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/ClinicWaveUser.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/ClinicWaveUser.java
@@ -45,4 +45,7 @@ public class ClinicWaveUser extends Audit implements Serializable {
 
   @OneToOne
   private Role role;
+
+  @OneToOne
+  private Address address;
 }


### PR DESCRIPTION
### Description:
This pull request introduces a new `Address` entity and updates the `ClinicWaveUser` entity to include a `OneToOne` relationship with the `Address` entity.

### Changes:
- **Address Entity:** Added a new `Address` entity in the `com.clinicwave.clinicwavecoredomainservice.user` package. This entity extends `Audit` and implements `Serializable`. It has fields for `id`, `addressLine`, `country`, `city`, `state`, and `zipCode`.
- **ClinicWaveUser Entity:** Updated the `ClinicWaveUser` entity in the `com.clinicwave.clinicwavecoredomainservice.user` package. A new `OneToOne` relationship is established with the `Address` entity.

### Purpose:
The purpose of this pull request is to enhance the `ClinicWaveUser` entity with address information and to ensure that address details are properly managed within their own `Address` entity.