### PR TITLE
Add UserType Entity and Update ClinicWaveUser Entity

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/ClinicWaveUser.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/ClinicWaveUser.java
@@ -48,4 +48,7 @@ public class ClinicWaveUser extends Audit implements Serializable {
 
   @OneToOne
   private Address address;
+
+  @OneToOne
+  private UserType userType;
 }

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/UserType.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/UserType.java
@@ -1,0 +1,30 @@
+package com.clinicwave.clinicwavecoredomainservice.user;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * @author aamir on 5/30/24
+ */
+@Entity
+@Table(name = "UserType")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserType extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String type;
+}


### PR DESCRIPTION
### Description:
This pull request introduces a new `UserType` entity and updates the `ClinicWaveUser` entity to include a `OneToOne` relationship with the `UserType` entity.

### Changes:
- **UserType Entity:** Added a new `UserType` entity in the `com.clinicwave.clinicwavecoredomainservice.user` package. This entity extends `Audit` and implements `Serializable`. It has fields for `id` and `type`.
- **ClinicWaveUser Entity:** Updated the `ClinicWaveUser` entity in the `com.clinicwave.clinicwavecoredomainservice.user` package. A new `OneToOne` relationship is established with the `UserType` entity.

### Purpose:
The purpose of this pull request is to enhance the `ClinicWaveUser` entity with user type information and to ensure that user type details are properly managed within their own `UserType` entity.