### PR TITLE
Add H2 database configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
 			<artifactId>lombok</artifactId>
 			<scope>annotationProcessor</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,16 @@
 spring.application.name=clinicwave-core-domain-service
+
+# datasource configuration
+spring.datasource.url=jdbc:h2:mem:clinicwave-core-domain
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# h2 console configuration
+spring.h2.console.enabled=true
+
+# jpa configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
### Description:
This pull request introduces changes to set up the project to use the H2 in-memory database for development and testing purposes.

### Changes:
- **Added H2 database dependency:** Added a dependency for the H2 database engine to the `pom.xml` file.
- **Configured H2 datasource:** Added datasource configuration properties for the H2 in-memory database to the `application.properties` file.
- **Enabled H2 console:** Enabled the H2 console by setting `spring.h2.console.enabled=true`.
- **Configured JPA properties:** Configured JPA properties for the H2 database dialect, DDL auto-generation, and SQL formatting.

### Purpose:
The purpose of this pull request is to provide a lightweight and easy-to-use database solution for development and testing environments. The H2 in-memory database offers a convenient way to work with a database without the need for a separate database server installation. This setup simplifies the development process and ensures a consistent database environment across different development setups.