### PR TITLE
Add DocumentStatus and DocumentStatusEnum

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/document/Document.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/document/Document.java
@@ -1,0 +1,41 @@
+package com.clinicwave.clinicwavecoredomainservice.document;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * @author aamir on 6/3/24
+ */
+@Entity
+@Table(name = "Document")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class Document extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Column(nullable = false)
+  private String title;
+
+  private String description;
+
+  @Column(nullable = false)
+  private String path;
+
+  @Column(nullable = false)
+  private String documentKey;
+
+  @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+  private DocumentStatus documentStatus;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/document/DocumentStatus.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/document/DocumentStatus.java
@@ -1,0 +1,32 @@
+package com.clinicwave.clinicwavecoredomainservice.document;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import com.clinicwave.clinicwavecoredomainservice.enums.DocumentStatusEnum;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * @author aamir on 6/3/24
+ */
+@Entity
+@Table(name = "DocumentStatus")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class DocumentStatus extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private DocumentStatusEnum status;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/enums/DocumentStatusEnum.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/enums/DocumentStatusEnum.java
@@ -1,0 +1,10 @@
+package com.clinicwave.clinicwavecoredomainservice.enums;
+
+/**
+ * @author aamir on 6/3/24
+ */
+public enum DocumentStatusEnum {
+  DRAFT,
+  PUBLISHED,
+  ARCHIVED
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/ClinicWaveUser.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/ClinicWaveUser.java
@@ -1,6 +1,7 @@
 package com.clinicwave.clinicwavecoredomainservice.user;
 
 import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import com.clinicwave.clinicwavecoredomainservice.document.Document;
 import com.clinicwave.clinicwavecoredomainservice.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
@@ -8,6 +9,7 @@ import lombok.*;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.util.Set;
 
 /**
  * @author aamir on 5/29/24
@@ -58,4 +60,7 @@ public class ClinicWaveUser extends Audit implements Serializable {
 
   @OneToOne
   private UserType userType;
+
+  @OneToMany(cascade = CascadeType.ALL)
+  private Set<Document> documentSet;
 }


### PR DESCRIPTION
### Description:
This pull request introduces new entities and updates existing ones to manage document status in the ClinicWave application.

### Changes:
- **Added DocumentStatusEnum:** A new enum `DocumentStatusEnum` has been added in the `enums` package. This enum represents the status of a document and includes values such as `DRAFT`, `PUBLISHED`, and `ARCHIVED`.
- **Added DocumentStatus Entity:** A new entity `DocumentStatus` has been added in the `document` package. This entity extends the `Audit` class and includes a field for `status` which uses the `DocumentStatusEnum`.
- **Updated Document Entity:** The `Document` entity has been updated to include a one-to-one relationship with the `DocumentStatus` entity.
- **Updated ClinicWaveUser Entity:** The `ClinicWaveUser` entity has been updated to include a one-to-many relationship with the `Document` entity.

### Purpose:
The purpose of this pull request is to enhance the document management capabilities of the ClinicWave application by introducing a status attribute for documents and linking it with the user entity.