### PR TITLE
Add Notification, NotificationType entities, and NotificationTypeEnum

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/enums/NotificationTypeEnum.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/enums/NotificationTypeEnum.java
@@ -1,0 +1,10 @@
+package com.clinicwave.clinicwavecoredomainservice.enums;
+
+/**
+ * @author aamir on 6/3/24
+ */
+public enum NotificationTypeEnum {
+  SMS,
+  EMAIL,
+  WEB
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/notification/Notification.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/notification/Notification.java
@@ -1,0 +1,50 @@
+package com.clinicwave.clinicwavecoredomainservice.notification;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * @author aamir on 6/3/24
+ */
+@Entity
+@Table(name = "Notification")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class Notification extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Column(nullable = false)
+  private String title;
+
+  private String body;
+
+  @Column(nullable = false)
+  private LocalDateTime notificationTime;
+
+  @Column(nullable = false)
+  private LocalDateTime expiryTime;
+
+  private LocalDateTime createdTime;
+
+  private LocalDateTime lastModifiedTime;
+
+  private Boolean isSpecificToUser;
+
+  private Boolean isActive = true;
+
+  @OneToOne
+  private NotificationType notificationType;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/notification/NotificationType.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/notification/NotificationType.java
@@ -1,0 +1,33 @@
+package com.clinicwave.clinicwavecoredomainservice.notification;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import com.clinicwave.clinicwavecoredomainservice.enums.NotificationTypeEnum;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * @author aamir on 6/3/24
+ */
+@Entity
+@Table(name = "NotificationType")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationType extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationTypeEnum type;
+}
+

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/ClinicWaveUser.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/ClinicWaveUser.java
@@ -3,6 +3,7 @@ package com.clinicwave.clinicwavecoredomainservice.user;
 import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
 import com.clinicwave.clinicwavecoredomainservice.document.Document;
 import com.clinicwave.clinicwavecoredomainservice.enums.Gender;
+import com.clinicwave.clinicwavecoredomainservice.notification.Notification;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -63,4 +64,7 @@ public class ClinicWaveUser extends Audit implements Serializable {
 
   @OneToMany(cascade = CascadeType.ALL)
   private Set<Document> documentSet;
+
+  @OneToMany(cascade = CascadeType.ALL)
+  private Set<Notification> notificationSet;
 }


### PR DESCRIPTION
### Description:
This pull request introduces new entities and updates existing ones to manage notifications in the ClinicWave application.

### Changes:
- **Added NotificationTypeEnum:** A new enum `NotificationTypeEnum` has been added in the `enums` package. This enum represents the type of a notification and includes values such as `SMS`, `EMAIL`, and `WEB`.
- **Added Notification Entity:** A new entity `Notification` has been added in the `notification` package. This entity extends the `Audit` class and includes various fields related to a notification, including a one-to-one relationship with the `NotificationType` entity.
- **Added NotificationType Entity:** A new entity `NotificationType` has been added in the `notification` package. This entity extends the `Audit` class and includes a field for `type` which uses the `NotificationTypeEnum`.
- **Updated ClinicWaveUser Entity:** The `ClinicWaveUser` entity has been updated to include a one-to-many relationship with the `Notification` entity.

### Purpose:
The purpose of this pull request is to enhance the notification management capabilities of the ClinicWave application by introducing a notification type attribute and linking it with the user entity.