### PR TITLE
Add doctor schedule and availability entities

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorAvailableDay.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorAvailableDay.java
@@ -1,0 +1,32 @@
+package com.clinicwave.clinicwavecoredomainservice.doctor;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.DayOfWeek;
+
+/**
+ * @author aamir on 6/5/24
+ */
+@Entity
+@Table(name = "DoctorAvailableDay")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class DoctorAvailableDay extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private DayOfWeek dayOfWeek;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorAvailableDayTime.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorAvailableDayTime.java
@@ -1,0 +1,36 @@
+package com.clinicwave.clinicwavecoredomainservice.doctor;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * @author aamir on 6/7/24
+ */
+@Entity
+@Table(name = "DoctorAvailableDayTime")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class DoctorAvailableDayTime extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @ManyToOne
+  private DoctorSchedule doctorSchedule;
+
+  @ManyToOne
+  private DoctorAvailableDay doctorAvailableDay;
+
+  @ManyToOne
+  private DoctorAvailableTime doctorAvailableTime;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorAvailableTime.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorAvailableTime.java
@@ -1,0 +1,34 @@
+package com.clinicwave.clinicwavecoredomainservice.doctor;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalTime;
+
+/**
+ * @author aamir on 6/5/24
+ */
+@Entity
+@Table(name = "DoctorAvailableTime")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class DoctorAvailableTime extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Column(nullable = false)
+  private LocalTime startTime;
+
+  @Column(nullable = false)
+  private LocalTime endTime;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorSchedule.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorSchedule.java
@@ -1,0 +1,40 @@
+package com.clinicwave.clinicwavecoredomainservice.doctor;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import com.clinicwave.clinicwavecoredomainservice.user.ClinicWaveUser;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * @author aamir on 6/5/24
+ */
+@Entity
+@Table(name = "DoctorSchedule")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class DoctorSchedule extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  private String message;
+
+  @OneToOne
+  private ClinicWaveUser doctor;
+
+  @OneToMany(cascade = CascadeType.ALL, mappedBy = "doctorSchedule")
+  private Set<DoctorAvailableDayTime> doctorAvailableDayTimeSet;
+
+  @OneToOne
+  private DoctorScheduleStatus doctorScheduleStatus;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorScheduleStatus.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/doctor/DoctorScheduleStatus.java
@@ -1,0 +1,32 @@
+package com.clinicwave.clinicwavecoredomainservice.doctor;
+
+import com.clinicwave.clinicwavecoredomainservice.audit.Audit;
+import com.clinicwave.clinicwavecoredomainservice.enums.DoctorScheduleStatusEnum;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * @author aamir on 6/5/24
+ */
+@Entity
+@Table(name = "DoctorScheduleStatus")
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class DoctorScheduleStatus extends Audit implements Serializable {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private DoctorScheduleStatusEnum status;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/enums/DayOfWeekEnum.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/enums/DayOfWeekEnum.java
@@ -1,0 +1,14 @@
+package com.clinicwave.clinicwavecoredomainservice.enums;
+
+/**
+ * @author aamir on 6/6/24
+ */
+public enum DayOfWeekEnum {
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY,
+  SUNDAY;
+}

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/enums/DoctorScheduleStatusEnum.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/enums/DoctorScheduleStatusEnum.java
@@ -1,0 +1,9 @@
+package com.clinicwave.clinicwavecoredomainservice.enums;
+
+/**
+ * @author aamir on 6/4/24
+ */
+public enum DoctorScheduleStatusEnum {
+  AVAILABLE,
+  UNAVAILABLE
+}


### PR DESCRIPTION
### Description:
This pull request introduces a new set of entities and enums to support the management of doctor schedules and availability.

### Changes:
- **Added DoctorAvailableDay entity:** This entity represents the days a doctor is available for appointments.
- **Added DoctorAvailableTime entity:** This entity represents the available time slots for a doctor's appointments.
- **Added DoctorAvailableDayTime entity:** This entity maps the available days and times for a doctor, linking the DoctorAvailableDay and DoctorAvailableTime entities.
- **Added DoctorSchedule entity:** This entity represents a doctor's schedule, containing information such as the doctor, available day and time slots, and schedule status.
- **Added DoctorScheduleStatus entity:** This entity represents the status of a doctor's schedule (available or unavailable).
- **Added DayOfWeekEnum enum:** This enum represents the days of the week.
- **Added DoctorScheduleStatusEnum enum:** This enum represents the status of a doctor's schedule (available or unavailable).

### Purpose:
The purpose of this pull request is to provide a robust system for managing doctor schedules and availability. By introducing these entities and enums, the application can effectively track and maintain the availability of doctors, allowing patients to schedule appointments during the appropriate times. This feature enhances the overall user experience and streamlines the appointment booking process.