### PR TITLE
Update Field Names in Permission and Role Entities

### DIFF
--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/Permission.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/Permission.java
@@ -26,5 +26,5 @@ public class Permission extends Audit implements Serializable {
   private Long id;
 
   @Column(nullable = false, unique = true)
-  private String name;
+  private String permissionName;
 }

--- a/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/Role.java
+++ b/src/main/java/com/clinicwave/clinicwavecoredomainservice/user/Role.java
@@ -27,7 +27,7 @@ public class Role extends Audit implements Serializable {
   private Long id;
 
   @Column(nullable = false, unique = true)
-  private String name;
+  private String roleName;
 
   @OneToMany(cascade = CascadeType.ALL, mappedBy = "role")
   private Set<RolePermission> rolePermissionSet;


### PR DESCRIPTION
### Description:
This pull request introduces improvements to the naming conventions used in the `Permission` and `Role` entities to enhance code readability and maintainability.

### Changes:
- **Rename `name` field in `Permission` entity to `permissionName`:** The `name` field in the `Permission` entity has been renamed to `permissionName` to provide a more descriptive and specific field name, clearly indicating that it represents the name or description of a permission.

- **Rename `name` field in `Role` entity to `roleName`:** The `name` field in the `Role` entity has been renamed to `roleName` to provide a more descriptive and specific field name, clearly indicating that it represents the name or description of a role.

### Purpose:
The purpose of this pull request is to improve the code quality and maintainability by adopting more descriptive and meaningful field names in the `Permission` and `Role` entities. These changes align with best practices and industry standards, making the codebase more readable and easier to understand for developers working with these entities. By providing clear and self-explanatory field names, the code becomes more intuitive and reduces the need for additional comments or documentation.